### PR TITLE
授業概要の入力ボックスに自動でフォーカスされてしまうのを修正

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -63,7 +63,6 @@
               type="search"
               trim
               @keypress.enter="search"
-              autofocus
             ></b-form-input>
           </b-col>
         </b-row>


### PR DESCRIPTION
- 科目名と授業概要の 2 つの input に autofocus がついていたがために、授業概要に自動でフォーカスがいってしまったと思われる