### PR TITLE
Docker イメージのパス（リポジトリ？）を修正

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: docker/metadata-action@v3
         id: docker_meta
         with:
-          images: ghcr.io/sylms/azuki
+          images: ghcr.io/sylms/daifuku
           tags: |
             type=sha,prefix={{date 'YYYYMMDD'}}-{{branch}}-open-coins-
       - uses: docker/build-push-action@v2


### PR DESCRIPTION
- GitHub Actions による Docker イメージのプッシュに失敗しないように
- azuki のをコピって使いまわしていたら修正するべき箇所を修正し忘れていた