### PR TITLE
open-coins 向け以外のイメージも想定してタグの名前変更

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,7 @@ jobs:
           images: ghcr.io/sylms/daifuku
           tags: |
             type=sha,prefix={{date 'YYYYMMDD'}}-{{branch}}-open-coins-
-            type=raw,value=latest
+            type=raw,value=latest-open-coins
       - uses: docker/build-push-action@v2
         with:
           context: .


### PR DESCRIPTION
- latest だと open-coins 向け以外のイメージを作成したときにその最新版を示すタグが競合してしまうので、そうならないように固有の名前を追加した