### PR TITLE
科目名と授業概要の両方が空だったときにエラーメッセージを表示するように / リクエストを送信しないように

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -285,7 +285,7 @@ export default Vue.extend({
 
     getSearchableErrorMessage: function (): string {
       if (!this.course_name_keyword && !this.course_overview_keyword) {
-        return "科目名と科目概要のどちらかは必須です";
+        return "科目名と授業概要のどちらかは必須です";
       }
       return "";
     },

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -148,6 +148,9 @@
         {{ getShortString(data.value) }}
       </template>
     </b-table>
+    <b-alert v-if="searchQueryErrorMessage" variant="danger" show>{{
+      searchQueryErrorMessage
+    }}</b-alert>
     <infinite-loading
       v-if="searched"
       @infinite="infiniteHandler"
@@ -193,6 +196,7 @@ export default Vue.extend({
     page: number;
     limit: number;
     searched: boolean;
+    searchQueryErrorMessage: string;
     infiniteLoadingIdentifier: number;
   } {
     return {
@@ -265,16 +269,25 @@ export default Vue.extend({
       page: 1,
       limit: 20,
       searched: false,
+      searchQueryErrorMessage: "",
       infiniteLoadingIdentifier: 0,
     };
   },
   methods: {
     search: async function () {
-      this.searched = true;
+      this.searchQueryErrorMessage = this.getSearchableErrorMessage();
+      this.searched = !this.searchQueryErrorMessage;
       this.page = 1;
       this.rows = [];
       // vue-infinite-loading を初期状態に戻すために、この変数に変更を加えている
       this.infiniteLoadingIdentifier++;
+    },
+
+    getSearchableErrorMessage: function (): string {
+      if (!this.course_name_keyword && !this.course_overview_keyword) {
+        return "科目名と科目概要のどちらかは必須です";
+      }
+      return "";
     },
 
     getShortString: function (str: string) {


### PR DESCRIPTION
- 科目名と授業概要の両方が空だったときに簡易的にエラーメッセージを表示するようにした。また、リクエストを送信しないようにした。
- Close #23 