### PR TITLE
表のヘッダーを上部に固定するように

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -96,7 +96,12 @@
         </b-row>
       </b-container>
     </div>
-    <b-table striped :items="rows" :fields="fields">
+    <b-table
+      striped
+      :items="rows"
+      :fields="fields"
+      thead-class="fixed-table-header"
+    >
       <template #cell(courseNumber)="data">
         <a
           :href="`https://kdb.tsukuba.ac.jp/syllabi/${data.item.year}/${data.item.courseNumber}/jpn/`"
@@ -350,5 +355,15 @@ export default Vue.extend({
 <style>
 .root {
   padding: 0px 15px;
+}
+
+.fixed-table-header {
+  position: sticky;
+  /* for Safari */
+  position: -webkit-sticky;
+
+  top: 0;
+
+  background-color: lightgray;
 }
 </style>


### PR DESCRIPTION
- 表のヘッダーを上部に固定するようにした
- Bootstrap Vue の `sticky-header` では、infinite-loading との相性が悪かった
  - 具体的には、一気に全件分を取得しようと大量のリクエストが発生してしまう
- 相性を解決するのは面倒だったので、雑に `position: sticky;` でどうにかした