### PR TITLE
表の表示がスマホなどでは積立てるような表示になるように

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -96,7 +96,12 @@
         </b-row>
       </b-container>
     </div>
-    <b-table striped :items="rows" :fields="fields">
+    <b-table
+      striped
+      :items="rows"
+      :fields="fields"
+      thead-class="fixed-table-header"
+    >
       <template #cell(courseNumber)="data">
         <a
           :href="`https://kdb.tsukuba.ac.jp/syllabi/${data.item.year}/${data.item.courseNumber}/jpn/`"
@@ -350,5 +355,15 @@ export default Vue.extend({
 <style>
 .root {
   padding: 0px 15px;
+}
+
+.fixed-table-header {
+  position: sticky;
+  /* for Safari */
+  position: -webkit-sticky;
+
+  top: 0;
+
+  background-color: lightgray;
 }
 </style>

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -100,6 +100,7 @@
       striped
       :items="rows"
       :fields="fields"
+      stacked="sm"
       thead-class="fixed-table-header"
     >
       <template #cell(courseNumber)="data">


### PR DESCRIPTION
- Bootstrap Vue の stacked を使用するようにした
- 
![2021-10-11_17-16-20](https://user-images.githubusercontent.com/37328795/136756466-8c6c6aa8-cfcb-4b98-93a6-a39845d707d9.png)
- #45 に依存するので Draft で作成
- Resolve #17 