### PR TITLE
add table-header transparent

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -365,6 +365,19 @@ export default Vue.extend({
 
   top: 0;
 
-  background-color: lightgray;
+  border-style: hidden;
+
+}
+
+@supports (backdrop-filter: blur(12px)) {
+  .fixed-table-header {
+    backdrop-filter: blur(12px);
+  }
+}
+
+@supports not (backdrop-filter: blur(12px)) {
+  .fixed-table-header {
+    background-color: lightgray;
+  }
 }
 </style>


### PR DESCRIPTION
ヘッダーが固定されるようになったので背景を透過しつつぼかすようにした。

Firefox は非対応のようなので、その場合は単に背景色を設定するようにした。