### PR TITLE
シラバスページのアーカイブ閲覧機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+# Web Archive file
+/public/wacz/*.wacz

--- a/README.md
+++ b/README.md
@@ -1,24 +1,7 @@
 # daifuku
 
-## Project setup
-```
-yarn install
-```
+## セットアップ
 
-### Compiles and hot-reloads for development
-```
-yarn serve
-```
+### Web アーカイブ機能をローカルで使う
 
-### Compiles and minifies for production
-```
-yarn build
-```
-
-### Lints and fixes files
-```
-yarn lint
-```
-
-### Customize configuration
-See [Configuration Reference](https://cli.vuejs.org/config/).
+- KdB のシラバスページをクロールしたデータが格納されている WACZ ファイルを `public/wacz/kdb_syllabi.wacz` に配置する。

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/vue-fontawesome": "^2.0.6",
     "bootstrap": "^5.0.2",
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",

--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -1,0 +1,3 @@
+<script src="https://cdn.jsdelivr.net/npm/replaywebpage@1.5.6/ui.js" type="application/javascript"></script>
+<replay-web-page source="/wacz/kdb_syllabi.wacz" embed="default" deepLink="true">
+</replay-web-page>

--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -1,3 +1,10 @@
-<script src="https://cdn.jsdelivr.net/npm/replaywebpage@1.5.6/ui.js" type="application/javascript"></script>
-<replay-web-page source="/wacz/kdb_syllabi.wacz" embed="default" deepLink="true">
+<script
+  src="https://cdn.jsdelivr.net/npm/replaywebpage@1.5.6/ui.js"
+  type="application/javascript"
+></script>
+<replay-web-page
+  source="/wacz/kdb_syllabi.wacz"
+  embed="default"
+  deepLink="true"
+>
 </replay-web-page>

--- a/public/archive/replay/sw.js
+++ b/public/archive/replay/sw.js
@@ -1,0 +1,1 @@
+importScripts("https://cdn.jsdelivr.net/npm/replaywebpage@1.5.6/sw.js");

--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -170,6 +170,15 @@
       <template #cell(applicationConditions)="data">
         {{ getShortString(data.value) }}
       </template>
+
+      <template #cell(archiveLink)="data">
+        <a
+          :href="`/archive/#query=https://kdb.tsukuba.ac.jp/syllabi/${data.item.year}/${data.item.courseNumber}/&view=resources&urlSearchType=prefix`"
+          target="_blank"
+          rel="noopener"
+          ><font-awesome-icon icon="external-link-alt"
+        /></a>
+      </template>
     </b-table>
     <b-alert v-if="searchQueryErrorMessage" variant="danger" show>{{
       searchQueryErrorMessage
@@ -197,10 +206,17 @@ import {
 import Vue from "vue";
 import InfiniteLoading from "vue-infinite-loading";
 
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faExternalLinkAlt);
+
 export default Vue.extend({
   name: "search",
   components: {
     InfiniteLoading,
+    FontAwesomeIcon,
   },
   metaInfo: {
     title: "sylms Explorer",
@@ -290,6 +306,10 @@ export default Vue.extend({
           //     ? row.remarks.substring(0, this.substringMaxNum)
           //     : null;
           // },
+        },
+        {
+          label: "アーカイブ",
+          key: "archiveLink",
         },
       ],
       rows: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,6 +903,30 @@
     "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
+"@fortawesome/fontawesome-common-types@^0.2.36":
+  version "0.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
+  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+
+"@fortawesome/fontawesome-svg-core@^1.2.36":
+  version "1.2.36"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz#4f2ea6f778298e0c47c6524ce2e7fd58eb6930e3"
+  integrity sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/free-solid-svg-icons@^5.15.4":
+  version "5.15.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
+  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.36"
+
+"@fortawesome/vue-fontawesome@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.6.tgz#87e691ed87f28f4667238573a29743f543a087f6"
+  integrity sha512-V3vT3flY15AKbUS31aZOP12awQI3aAzkr2B1KnqcHLmwrmy51DW3pwyBczKdypV8QxBZ8U68Hl2XxK2nudTxpg==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"


### PR DESCRIPTION
- https://github.com/webrecorder/replayweb.page の埋め込みを利用してシラバスのアーカイブを閲覧できるようにした
- 一番右にアーカイブを閲覧するページへのリンク用カラムを追加した
   ![ss_2021-12-09_00-22-14](https://user-images.githubusercontent.com/37328795/145234888-df8c395c-57f5-4eb1-9c5c-a6e76cdb97c6.png)
- そのリンクにアクセスするとその科目のシラバスページのアーカイブ一覧が表示される
  - 年度、表示言語などは時間ができたときに調整する予定
  ![ss_2021-12-09_00-23-24](https://user-images.githubusercontent.com/37328795/145235167-83e3b22a-4cd4-4290-a25f-e78157ecc6c3.png)
- シラバスページはこんな感じで表示される
 ![ss_2021-12-09_00-23-44](https://user-images.githubusercontent.com/37328795/145235332-12990cb8-abe3-4fd2-af93-b1c0b860608e.png)
 