### PR TITLE
シラバスへのリンクを2種類にした

### DIFF
--- a/src/views/Search.vue
+++ b/src/views/Search.vue
@@ -211,6 +211,12 @@
                   target="_blank"
                   rel="noopener"
                   >{{ data.value }}</a
+                ><br />
+                <a
+                  :href="`https://kdb.tsukuba.ac.jp/syllabi/${data.item.year}/${data.item.courseNumber}/jpn/0`"
+                  target="_blank"
+                  rel="noopener"
+                  >シラバス最新版(ある場合)</a
                 >
               </template>
 


### PR DESCRIPTION
動く　　 https://kdb.tsukuba.ac.jp/syllabi/2022/01AA009/jpn/0
動かない https://kdb.tsukuba.ac.jp/syllabi/2022/01AA009/jpn/

動く　　 https://kdb.tsukuba.ac.jp/syllabi/2022/01DF102/jpn/
動かない https://kdb.tsukuba.ac.jp/syllabi/2022/01DF102/jpn/0


のようにシラバスへのリンクを単純にすることが難しくなったことへの対応

両方へのリンクを貼ることにした