### PR TITLE
WACZ が更新されないのを修正（するはず）

### DIFF
--- a/public/archive/index.html
+++ b/public/archive/index.html
@@ -3,7 +3,7 @@
   type="application/javascript"
 ></script>
 <replay-web-page
-  source="/wacz/kdb_syllabi.wacz"
+  source="/wacz/kdb_syllabi.wacz?v=2"
   embed="default"
   deepLink="true"
 >


### PR DESCRIPTION
- WACZ の中身を更新したがビューアーの情報が更新されない問題が発生していた。
- そこで、とりあえず WACZ のパスにキャッシュクリア用のパラメーターを付与するようにした。